### PR TITLE
JSON parse error 에 대한 ExceptionHandler 처리

### DIFF
--- a/src/main/java/com/app/todolist/web/exception/ErrorCode.java
+++ b/src/main/java/com/app/todolist/web/exception/ErrorCode.java
@@ -9,7 +9,8 @@ import org.springframework.http.HttpStatus;
 public enum ErrorCode {
 
     DUPLICATED_MEMBER_ID(HttpStatus.CONFLICT, "이미 가입된 이메일이 존재합니다."),
-    MEMBER_NOT_FOUND(HttpStatus.BAD_REQUEST, "회원이 존재하지 않습니다.");
+    MEMBER_NOT_FOUND(HttpStatus.BAD_REQUEST, "회원이 존재하지 않습니다."),
+    INVALID_JSON_INPUT(HttpStatus.BAD_REQUEST, "%s 필드 값이 잘못되었습니다. [%s] 타입이어야 합니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/app/todolist/web/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/app/todolist/web/exception/GlobalExceptionHandler.java
@@ -8,6 +8,7 @@ import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.validation.BindException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.resource.NoResourceFoundException;
 
 import java.util.Objects;
 
@@ -41,5 +42,19 @@ public class GlobalExceptionHandler {
         TodoExceptionResponse errorResult = new TodoExceptionResponse(
                 exception.getExceptionHttpStatus(), exception.getExceptionMessage());
         return new ResponseEntity<>(errorResult, exception.getExceptionHttpStatus());
+    }
+
+    @ExceptionHandler(NoResourceFoundException.class)
+    public ResponseEntity<TodoExceptionResponse> responseNoResourceFoundException() {
+        HttpStatus httpStatus = HttpStatus.NOT_FOUND;
+        TodoExceptionResponse errorResult = new TodoExceptionResponse(httpStatus, "잘못된 앤드 포인트 입니다.");
+        return new ResponseEntity<>(errorResult, httpStatus);
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<TodoExceptionResponse> responseException() {
+        HttpStatus httpStatus = HttpStatus.INTERNAL_SERVER_ERROR;
+        TodoExceptionResponse errorResponse = new TodoExceptionResponse(httpStatus, "서버 에러 입니다.");
+        return new ResponseEntity<>(errorResponse, httpStatus);
     }
 }

--- a/src/main/java/com/app/todolist/web/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/app/todolist/web/exception/GlobalExceptionHandler.java
@@ -1,15 +1,14 @@
 package com.app.todolist.web.exception;
 
 import com.app.todolist.web.exception.dto.TodoExceptionResponse;
+import com.fasterxml.jackson.databind.exc.InvalidFormatException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.validation.BindException;
-import org.springframework.validation.FieldError;
-import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
-import java.util.List;
 import java.util.Objects;
 
 @RestControllerAdvice
@@ -24,12 +23,15 @@ public class GlobalExceptionHandler {
         );
     }
 
-    @ExceptionHandler(MethodArgumentNotValidException.class)
-    public ResponseEntity<TodoExceptionResponse> responseMethodArgumentNotValidException(BindException exception) {
-        List<FieldError> fieldErrors = exception.getBindingResult().getFieldErrors();
-        String message = fieldErrors.stream().map(FieldError::getField).toList().toString();
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ResponseEntity<TodoExceptionResponse> responseMethodArgumentNotValidException(HttpMessageNotReadableException exception) {
+        InvalidFormatException invalidFormatException = (InvalidFormatException) exception.getCause();
+        String fieldName = invalidFormatException.getPath().getFirst().getFieldName();
+        String targetType = invalidFormatException.getTargetType().getSimpleName();
+
+        String errorMessage = String.format(ErrorCode.INVALID_JSON_INPUT.getMessage(), fieldName, targetType);
         HttpStatus httpStatus = HttpStatus.BAD_REQUEST;
-        String errorMessage = message + " 필드 값이 잘못되었습니다.";
+        
         return new ResponseEntity<>(
                 new TodoExceptionResponse(httpStatus, Objects.requireNonNull(errorMessage)), httpStatus);
     }

--- a/src/main/java/com/app/todolist/web/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/app/todolist/web/exception/GlobalExceptionHandler.java
@@ -24,20 +24,20 @@ public class GlobalExceptionHandler {
     }
 
     @ExceptionHandler(HttpMessageNotReadableException.class)
-    public ResponseEntity<TodoExceptionResponse> responseMethodArgumentNotValidException(HttpMessageNotReadableException exception) {
+    public ResponseEntity<TodoExceptionResponse> requestHttpMessageNotReadableException(HttpMessageNotReadableException exception) {
         InvalidFormatException invalidFormatException = (InvalidFormatException) exception.getCause();
         String fieldName = invalidFormatException.getPath().getFirst().getFieldName();
         String targetType = invalidFormatException.getTargetType().getSimpleName();
 
         String errorMessage = String.format(ErrorCode.INVALID_JSON_INPUT.getMessage(), fieldName, targetType);
         HttpStatus httpStatus = HttpStatus.BAD_REQUEST;
-        
+
         return new ResponseEntity<>(
                 new TodoExceptionResponse(httpStatus, Objects.requireNonNull(errorMessage)), httpStatus);
     }
 
     @ExceptionHandler(TodoApplicationException.class)
-    public ResponseEntity<TodoExceptionResponse> responseApplicationException(TodoApplicationException exception) {
+    public ResponseEntity<TodoExceptionResponse> responseTodoApplicationException(TodoApplicationException exception) {
         TodoExceptionResponse errorResult = new TodoExceptionResponse(
                 exception.getExceptionHttpStatus(), exception.getExceptionMessage());
         return new ResponseEntity<>(errorResult, exception.getExceptionHttpStatus());

--- a/src/test/java/com/app/todolist/web/exception/GlobalExceptionHandlerTest.java
+++ b/src/test/java/com/app/todolist/web/exception/GlobalExceptionHandlerTest.java
@@ -106,6 +106,44 @@ public class GlobalExceptionHandlerTest {
         assertThat(response.getBody().getCode()).isEqualTo(exceptionStatus.value());
         assertThat(response.getBody().getMessage()).isEqualTo(exceptionMessage);
     }
+
+    @Test
+    @DisplayName("잘못된 엔드 포인트 요청 시 GlobalExceptionHandler가 NoResourceFoundException을 처리한다.")
+    public void responseNoResourceFoundExceptionTest() {
+        // given
+        GlobalExceptionHandler globalExceptionHandler = new GlobalExceptionHandler();
+
+        HttpStatus exceptionStatus = HttpStatus.NOT_FOUND;
+        String exceptionMessage = "잘못된 앤드 포인트 입니다.";
+
+        // when
+        ResponseEntity<TodoExceptionResponse> response = globalExceptionHandler.responseNoResourceFoundException();
+
+        // then
+        assertThat(response.getStatusCode()).isEqualTo(exceptionStatus);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().getCode()).isEqualTo(exceptionStatus.value());
+        assertThat(response.getBody().getMessage()).isEqualTo(exceptionMessage);
+    }
+
+    @Test
+    @DisplayName("일반 Exception 발생 시 GlobalExceptionHandler가 INTERNAL_SERVER_ERROR를 처리한다.")
+    public void responseExceptionTest() {
+        // given
+        GlobalExceptionHandler globalExceptionHandler = new GlobalExceptionHandler();
+
+        HttpStatus exceptionStatus = HttpStatus.INTERNAL_SERVER_ERROR;
+        String exceptionMessage = "서버 에러 입니다.";
+
+        // when
+        ResponseEntity<TodoExceptionResponse> response = globalExceptionHandler.responseException();
+
+        // then
+        assertThat(response.getStatusCode()).isEqualTo(exceptionStatus);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().getCode()).isEqualTo(exceptionStatus.value());
+        assertThat(response.getBody().getMessage()).isEqualTo(exceptionMessage);
+    }
 }
 
 class ExampleRequest {

--- a/src/test/java/com/app/todolist/web/exception/GlobalExceptionHandlerTest.java
+++ b/src/test/java/com/app/todolist/web/exception/GlobalExceptionHandlerTest.java
@@ -86,7 +86,7 @@ public class GlobalExceptionHandlerTest {
     }
 
     @Test
-    @DisplayName("커스텀 예외 TodoApplicationException 발생 시 지정한 ErrorCode를 처리한다.")
+    @DisplayName("커스텀 예외 TodoApplicationException 발생 시 지정한 ErrorCode를 응답한다.")
     public void responseTodoApplicationExceptionTest() {
         // given
         GlobalExceptionHandler globalExceptionHandler = new GlobalExceptionHandler();

--- a/src/test/java/com/app/todolist/web/exception/GlobalExceptionHandlerTest.java
+++ b/src/test/java/com/app/todolist/web/exception/GlobalExceptionHandlerTest.java
@@ -1,0 +1,114 @@
+package com.app.todolist.web.exception;
+
+import com.app.todolist.web.exception.dto.TodoExceptionResponse;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.exc.InvalidFormatException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.validation.BeanPropertyBindingResult;
+import org.springframework.validation.BindException;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.FieldError;
+
+import java.util.Objects;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class GlobalExceptionHandlerTest {
+
+    @Test
+    @DisplayName("잘못된 값 요청 시 GlobalExceptionHandler가 BindException을 처리한다.")
+    public void responseBindExceptionTest() {
+        // given
+        GlobalExceptionHandler globalExceptionHandler = new GlobalExceptionHandler();
+
+        Object target = new Object();
+        String objectName = "BindException";
+        BindingResult bindingResult = new BeanPropertyBindingResult(target, objectName);
+
+        String fieldName = "todo";
+        String rejectedValue = "invalid value";
+        String errorMessage = "Value is invalid";
+        bindingResult.addError(new FieldError(objectName, fieldName, rejectedValue, false, null, null, errorMessage));
+
+        BindException bindException = new BindException(bindingResult);
+
+        // when
+        ResponseEntity<TodoExceptionResponse> response = globalExceptionHandler.responseBindException(bindException);
+
+        // then
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().getCode()).isEqualTo(400);
+        assertThat(response.getBody().getMessage()).contains(errorMessage);
+
+        FieldError fieldError = bindException.getFieldError();
+        assertThat(fieldError).isNotNull();
+        assertThat(fieldError.getField()).isEqualTo(fieldName);
+        assertThat(fieldError.getRejectedValue()).isEqualTo(rejectedValue);
+        assertThat(fieldError.getDefaultMessage()).isEqualTo(errorMessage);
+    }
+
+    @Test
+    @DisplayName("잘못된 JSON 입력 시 GlobalExceptionHandler가 HttpMessageNotReadableException을 처리한다")
+    public void requestHttpMessageNotReadableExceptionTest() throws Exception {
+        // given
+        GlobalExceptionHandler globalExceptionHandler = new GlobalExceptionHandler();
+        ObjectMapper objectMapper = new ObjectMapper();
+
+        String invalidJson = "{ \"id\": \"a\", \"todo\": \"123\" }";
+
+        HttpMessageNotReadableException exception = null;
+        try {
+            objectMapper.readValue(invalidJson, ExampleRequest.class);
+        } catch (InvalidFormatException invalidFormatException) {
+            exception = new HttpMessageNotReadableException("Invalid JSON format", invalidFormatException);
+        }
+
+        String expectedFieldName = "id";
+        String expectedTargetType = "Long";
+        String expectedMessage = String.format(
+                ErrorCode.INVALID_JSON_INPUT.getMessage(), expectedFieldName, expectedTargetType
+        );
+
+        // when
+        ResponseEntity<TodoExceptionResponse> response = globalExceptionHandler
+                .requestHttpMessageNotReadableException(Objects.requireNonNull(exception));
+
+        // then
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().getCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+        assertThat(response.getBody().getMessage()).isEqualTo(expectedMessage);
+    }
+
+    @Test
+    @DisplayName("커스텀 예외 TodoApplicationException 발생 시 지정한 ErrorCode를 처리한다.")
+    public void responseTodoApplicationExceptionTest() {
+        // given
+        GlobalExceptionHandler globalExceptionHandler = new GlobalExceptionHandler();
+
+        HttpStatus exceptionStatus = ErrorCode.DUPLICATED_MEMBER_ID.getHttpStatus();
+        String exceptionMessage = ErrorCode.DUPLICATED_MEMBER_ID.getMessage();
+
+        TodoApplicationException exception = new TodoApplicationException(ErrorCode.DUPLICATED_MEMBER_ID);
+
+        // when
+        ResponseEntity<TodoExceptionResponse> response = globalExceptionHandler
+                .responseTodoApplicationException(exception);
+
+        // then
+        assertThat(response.getStatusCode()).isEqualTo(exceptionStatus);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().getCode()).isEqualTo(exceptionStatus.value());
+        assertThat(response.getBody().getMessage()).isEqualTo(exceptionMessage);
+    }
+}
+
+class ExampleRequest {
+    public Long id;
+    public String todo;
+}


### PR DESCRIPTION
- JSON parse error 에 대한 너무 큰 범위로 잡던 ExceptionHandler 처리 로직 변경
- GlobalExceptionHandler 유닛 테스트코드 작성

```json
// BAD_REQUEST ex
{
    "memberId": "a", // Long타입이 아닌 String타입 요청
    "title": "todo title",
    "content": "todo content"
}
```

해당 BAD_REQUEST에 대한 JSON parse error ExceptionHandler  처리

```json
// as-is
{
    "timestamp": "2024-10-03T10:32:44.674+00:00",
    "status": 400,
    "error": "Bad Request",
    "trace": "......",
    "message": "...... 에러 메세지",
    "path": "....."
}

// to-be
{
    "code": 400,
    "message": "'field' 필드 값이 잘못되었습니다. ['type'] 타입이어야 합니다."
}
```

close #24