### PR TITLE
Todo 상태 변경 기능 구현

### DIFF
--- a/src/main/java/com/app/todolist/api/todos/controller/TodoController.java
+++ b/src/main/java/com/app/todolist/api/todos/controller/TodoController.java
@@ -39,4 +39,11 @@ public class TodoController {
         Todo updatedTodo = todoService.updateTodo(id, todoUpdateRequest.toUpdate());
         return TodoUpdateResponse.of(updatedTodo);
     }
+
+    @PutMapping("/status/{id}")
+    public TodoUpdateResponse updateTodoStatus(@PathVariable Long id,
+                                               @RequestBody @Valid TodoStatusUpdateRequest todoStatusUpdateRequest) {
+        Todo updateTodoStatus = todoService.updateTodoStatus(id, todoStatusUpdateRequest.getStatus());
+        return TodoUpdateResponse.of(updateTodoStatus);
+    }
 }

--- a/src/main/java/com/app/todolist/api/todos/controller/TodoController.java
+++ b/src/main/java/com/app/todolist/api/todos/controller/TodoController.java
@@ -40,10 +40,10 @@ public class TodoController {
         return TodoUpdateResponse.of(updatedTodo);
     }
 
-    @PutMapping("/status/{id}")
-    public TodoUpdateResponse updateTodoStatus(@PathVariable Long id,
-                                               @RequestBody @Valid TodoStatusUpdateRequest todoStatusUpdateRequest) {
-        Todo updateTodoStatus = todoService.updateTodoStatus(id, todoStatusUpdateRequest.getStatus());
-        return TodoUpdateResponse.of(updateTodoStatus);
+    @PutMapping("/{id}/status")
+    public TodoResponse updateTodoStatus(@PathVariable Long id,
+                                         @RequestBody @Valid TodoStatusUpdateRequest todoStatusUpdateRequest) {
+        Todo todo = todoService.updateTodoStatus(id, todoStatusUpdateRequest.getStatus());
+        return TodoResponse.of(todo);
     }
 }

--- a/src/main/java/com/app/todolist/api/todos/controller/dto/TodoResponse.java
+++ b/src/main/java/com/app/todolist/api/todos/controller/dto/TodoResponse.java
@@ -30,7 +30,7 @@ public class TodoResponse {
                 .id(todo.getId())
                 .title(todo.getTitle())
                 .content(todo.getContent())
-                .status(TodoStatus.TODO)
+                .status(todo.getStatus())
                 .createdAt(todo.getCreatedAt())
                 .updatedAt(todo.getUpdatedAt())
                 .member(new TodoMemberInfo(todo.getMember().getId(), todo.getMember().getEmail()))

--- a/src/main/java/com/app/todolist/api/todos/controller/dto/TodoStatusUpdateRequest.java
+++ b/src/main/java/com/app/todolist/api/todos/controller/dto/TodoStatusUpdateRequest.java
@@ -1,0 +1,12 @@
+package com.app.todolist.api.todos.controller.dto;
+
+import com.app.todolist.domain.todos.TodoStatus;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+@Getter
+public class TodoStatusUpdateRequest {
+
+    @NotNull
+    private TodoStatus status;
+}

--- a/src/main/java/com/app/todolist/api/todos/controller/dto/TodoStatusUpdateRequest.java
+++ b/src/main/java/com/app/todolist/api/todos/controller/dto/TodoStatusUpdateRequest.java
@@ -3,8 +3,10 @@ package com.app.todolist.api.todos.controller.dto;
 import com.app.todolist.domain.todos.TodoStatus;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
+import lombok.Setter;
 
 @Getter
+@Setter
 public class TodoStatusUpdateRequest {
 
     @NotNull

--- a/src/main/java/com/app/todolist/api/todos/service/TodoService.java
+++ b/src/main/java/com/app/todolist/api/todos/service/TodoService.java
@@ -43,9 +43,9 @@ public class TodoService {
     }
 
     @Transactional
-    public Todo updateTodoStatus(Long id, TodoStatus status) {
+    public Todo updateTodoStatus(Long id, TodoStatus todoStatus) {
         Todo existingTodo = findTodoById(id);
-        existingTodo.updateStatus(status);
+        existingTodo.updateStatus(todoStatus);
         return existingTodo;
     }
 

--- a/src/main/java/com/app/todolist/api/todos/service/TodoService.java
+++ b/src/main/java/com/app/todolist/api/todos/service/TodoService.java
@@ -44,9 +44,9 @@ public class TodoService {
 
     @Transactional
     public Todo updateTodoStatus(Long id, TodoStatus todoStatus) {
-        Todo existingTodo = findTodoById(id);
-        existingTodo.updateStatus(todoStatus);
-        return existingTodo;
+        Todo todo = findTodoById(id);
+        todo.updateStatus(todoStatus);
+        return todo;
     }
 
     public PaginationResponse<TodoSearchResponse> searchTodosByOptions(TodosWithOptions todosWithOptions) {

--- a/src/main/java/com/app/todolist/api/todos/service/TodoService.java
+++ b/src/main/java/com/app/todolist/api/todos/service/TodoService.java
@@ -6,6 +6,7 @@ import com.app.todolist.api.todos.service.dto.TodoUpdateInfo;
 import com.app.todolist.api.todos.service.dto.TodosWithOptions;
 import com.app.todolist.domain.members.Member;
 import com.app.todolist.domain.todos.Todo;
+import com.app.todolist.domain.todos.TodoStatus;
 import com.app.todolist.domain.todos.repository.TodoQueryRepository;
 import com.app.todolist.domain.todos.repository.TodoRepository;
 import com.app.todolist.web.exception.ErrorCode;
@@ -38,6 +39,13 @@ public class TodoService {
     public Todo updateTodo(Long id, TodoUpdateInfo todoUpdateInfo) {
         Todo existingTodo = findTodoById(id);
         existingTodo.update(todoUpdateInfo.getTitle(), todoUpdateInfo.getContent());
+        return existingTodo;
+    }
+
+    @Transactional
+    public Todo updateTodoStatus(Long id, TodoStatus status) {
+        Todo existingTodo = findTodoById(id);
+        existingTodo.updateStatus(status);
         return existingTodo;
     }
 

--- a/src/main/java/com/app/todolist/domain/todos/Todo.java
+++ b/src/main/java/com/app/todolist/domain/todos/Todo.java
@@ -36,4 +36,8 @@ public class Todo extends BaseEntity {
         this.title = title;
         this.content = content;
     }
+
+    public void updateStatus(TodoStatus todoStatus) {
+        this.status = todoStatus;
+    }
 }

--- a/src/main/java/com/app/todolist/domain/todos/TodoStatus.java
+++ b/src/main/java/com/app/todolist/domain/todos/TodoStatus.java
@@ -6,7 +6,8 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum TodoStatus {
-    TODO("할일");
+    TODO("할일"),
+    DONE("완료");
 
     private final String type;
 }

--- a/src/test/java/com/app/todolist/api/todos/controller/dto/TodoStatusUpdateRequestTest.java
+++ b/src/test/java/com/app/todolist/api/todos/controller/dto/TodoStatusUpdateRequestTest.java
@@ -1,0 +1,48 @@
+package com.app.todolist.api.todos.controller.dto;
+
+import com.app.todolist.domain.todos.TodoStatus;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+
+class TodoStatusUpdateRequestTest {
+
+    @Test
+    @DisplayName("status가 null일 경우 예외가 발생한다.")
+    public void statusNotNullValidTest() {
+        // given
+        Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
+        TodoStatusUpdateRequest todoStatusUpdateRequest = new TodoStatusUpdateRequest();
+        todoStatusUpdateRequest.setStatus(null);
+
+        // when
+        Set<ConstraintViolation<TodoStatusUpdateRequest>> violations = validator.validate(todoStatusUpdateRequest);
+
+        // then
+        Assertions.assertThat(violations)
+                .extracting(ConstraintViolation::getMessage)
+                .contains("널이어서는 안됩니다")
+                .hasSize(1);
+    }
+
+    @Test
+    @DisplayName("status를 정상적으로 입력할 경우 예외가 발생하지 않는다.")
+    public void statusValidSuccessTest() {
+        // given
+        Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
+        TodoStatusUpdateRequest todoStatusUpdateRequest = new TodoStatusUpdateRequest();
+        todoStatusUpdateRequest.setStatus(TodoStatus.TODO);
+
+        // when
+        Set<ConstraintViolation<TodoStatusUpdateRequest>> violations = validator.validate(todoStatusUpdateRequest);
+
+        // then
+        Assertions.assertThat(violations).isEmpty();
+    }
+
+}

--- a/src/test/java/com/app/todolist/api/todos/service/TodoServiceTest.java
+++ b/src/test/java/com/app/todolist/api/todos/service/TodoServiceTest.java
@@ -297,4 +297,37 @@ class TodoServiceTest {
         assertThat(exception.getExceptionMessage()).isEqualTo("TODO가 존재하지 않습니다.");
     }
 
+    @Test
+    @DisplayName("존재하는 todo의 상태를 변경할 수 있다.")
+    public void todoStatusUpdateTest() {
+        // given
+        Member savedMember = createMember();
+        Todo existingTodo = createTodo(savedMember, "todo-list", "hello");
+
+        // when
+        todoService.updateTodoStatus(existingTodo.getId(), TodoStatus.DONE);
+
+        // then
+        Todo updatedTodo = todoRepository.findById(existingTodo.getId()).orElseThrow();
+        assertThat(updatedTodo.getStatus()).isEqualTo(TodoStatus.DONE);
+    }
+
+    @Test
+    @DisplayName("존재하는 todo의 상태가 변경 될 경우 변경 된 시간이 updatedAt에 저장된다.")
+    public void todoStatusUpdatedAtTest() {
+        // given
+        Member savedMember = createMember();
+        Todo existingTodo = createTodo(savedMember, "todo-list", "hello");
+
+        LocalDateTime previousUpdatedAt = existingTodo.getUpdatedAt();
+
+        // when
+        todoService.updateTodoStatus(existingTodo.getId(), TodoStatus.DONE);
+
+        // then
+        Todo updatedTodo = todoRepository.findById(existingTodo.getId()).orElseThrow();
+        assertThat(updatedTodo.getUpdatedAt()).isNotNull();
+        assertThat(updatedTodo.getUpdatedAt()).isAfter(previousUpdatedAt);
+    }
+
 }


### PR DESCRIPTION
Todo 상태 변경
[PUT] /api/todos/{id}/status
status 가 null일 경우 예외가 발생한다.
잘못된 status를 요청 할 경우 예외가 발생한다.
상태값을 변경하고자 하는 Todo가 존재하지 않을 시 예외가 발생한다.

RequestBody
```json
{
  "status": "DONE"
}
```
ResponseBody
```json
{
    "id": 1,
    "title": "todo title",
    "content": "todo content",
    "status": "DONE",
    "createdAt": "2024-11-02 16:19:23",
    "updatedAt": "2024-11-06 15:40:19",
    "member": {
        "id": 1,
        "email": "tao@exemple.com"
    }
}
```

```json
// status null에 대한 예외 발생
{
    "code": 400,
    "message": "널이어서는 안됩니다"
}
```

```json
// 잘못된 status 값에 대한 예외 발생
{
    "code": 400,
    "message": "status 필드 값이 잘못되었습니다. [TodoStatus] 타입이어야 합니다."
}
```

```json
// 존재하지않는 todo 예외 발생
{
    "code": 400,
    "message": "TODO가 존재하지 않습니다."
}
```

close #31 