### PR TITLE
[#37] Redis 의존성 추가 및 Config 설정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,9 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
 
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    implementation 'org.springframework.session:spring-session-data-redis'
+
     implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
     annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
     annotationProcessor "jakarta.annotation:jakarta.annotation-api"

--- a/src/main/java/com/app/todolist/config/redis/RedisConfig.java
+++ b/src/main/java/com/app/todolist/config/redis/RedisConfig.java
@@ -1,0 +1,40 @@
+package com.app.todolist.config.redis;
+
+import com.app.todolist.config.redis.dto.MemberSession;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+import org.springframework.session.data.redis.config.annotation.web.http.EnableRedisHttpSession;
+
+@Configuration
+@EnableRedisHttpSession
+public class RedisConfig {
+
+    @Value("${spring.data.redis.host}")
+    private String host;
+
+    @Value("${spring.data.redis.port}")
+    private int port;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(
+                new RedisStandaloneConfiguration(host, port)
+        );
+    }
+
+    @Bean
+    public RedisTemplate<String, MemberSession> redisTemplate() {
+        RedisTemplate<String, MemberSession> template = new RedisTemplate<>();
+        template.setConnectionFactory(redisConnectionFactory());
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setValueSerializer(new Jackson2JsonRedisSerializer<>(MemberSession.class));
+        return template;
+    }
+}

--- a/src/main/java/com/app/todolist/config/redis/dto/MemberSession.java
+++ b/src/main/java/com/app/todolist/config/redis/dto/MemberSession.java
@@ -1,0 +1,12 @@
+package com.app.todolist.config.redis.dto;
+
+import lombok.Getter;
+
+@Getter
+public class MemberSession {
+    private final Long id;
+
+    public MemberSession(Long id) {
+        this.id = id;
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,7 +1,15 @@
 server:
   port: 80
+  servlet:
+    session:
+      timeout: ${SESSION_TIMEOUT}
 
 spring:
+  data:
+    redis:
+      host: ${REDIS_HOST}
+      port: ${REDIS_PORT}
+
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
     url: ${MYSQL_URL}


### PR DESCRIPTION
Redis 의존성 추가 및 config 설정

Redis Value 저장 방식을 class 객체로 받기 위해 Serializer 방식을 Jackson2JsonRedisSerializer로 설정

```json
// GenericJackson2JsonRedisSerializer 사용 시 Redis 저장 값
{
  "@class": "com.app.todolist.config.redis.dto.MemberSession",
  "id": 1
}
```
서버에서 해당 객체에 대한 구조 변경 시 세션 데이터 유효성 문제가 발생할 수 있습니다.
> 예) 해당 객체 디렉토리 구조 변경 시 모든 사용자 계정 로그아웃


```json
// Jackson2JsonRedisSerializer 사용 시 Redis 저장 값
{
  "id": 1
}
```

Jackson2JsonRedisSerializer를 사용해 저장함으로써 클래스 경로가 포함된 메타 정보 문제를 방지할 수 있습니다.

close #37 