### PR TITLE
[#39] 로그인 기능 구현

### DIFF
--- a/src/main/java/com/app/todolist/api/members/controller/MemberController.java
+++ b/src/main/java/com/app/todolist/api/members/controller/MemberController.java
@@ -1,9 +1,12 @@
 package com.app.todolist.api.members.controller;
 
+import com.app.todolist.api.members.controller.dto.request.MemberLoginRequest;
 import com.app.todolist.api.members.controller.dto.request.MemberRequest;
 import com.app.todolist.api.members.controller.dto.response.MemberResponse;
 import com.app.todolist.api.members.service.MemberService;
 import com.app.todolist.domain.members.Member;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -22,5 +25,12 @@ public class MemberController {
     public MemberResponse createMember(@RequestBody @Valid MemberRequest memberRequest) {
         Member member = memberService.createMember(memberRequest.toEntity());
         return MemberResponse.of(member);
+    }
+
+    @PostMapping("/login")
+    public void login(@RequestBody @Valid MemberLoginRequest memberLoginRequest,
+                      HttpServletResponse httpServletResponse) {
+        Cookie cookie = memberService.login(memberLoginRequest.toLogin());
+        httpServletResponse.addCookie(cookie);
     }
 }

--- a/src/main/java/com/app/todolist/api/members/controller/dto/request/MemberLoginRequest.java
+++ b/src/main/java/com/app/todolist/api/members/controller/dto/request/MemberLoginRequest.java
@@ -1,0 +1,19 @@
+package com.app.todolist.api.members.controller.dto.request;
+
+import com.app.todolist.api.members.service.dto.MemberLoginInfo;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+
+@Getter
+public class MemberLoginRequest {
+
+    @NotBlank(message = "이메일을 입력하세요.")
+    private String email;
+
+    @NotBlank(message = "비밀번호를 입력하세요.")
+    private String password;
+
+    public MemberLoginInfo toLogin() {
+        return new MemberLoginInfo(email, password);
+    }
+}

--- a/src/main/java/com/app/todolist/api/members/service/MemberService.java
+++ b/src/main/java/com/app/todolist/api/members/service/MemberService.java
@@ -1,23 +1,52 @@
 package com.app.todolist.api.members.service;
 
+import com.app.todolist.api.members.service.dto.MemberLoginInfo;
+import com.app.todolist.config.redis.dto.MemberSession;
 import com.app.todolist.domain.members.Member;
 import com.app.todolist.domain.members.repository.MemberRepository;
 import com.app.todolist.web.exception.ErrorCode;
 import com.app.todolist.web.exception.TodoApplicationException;
+import jakarta.servlet.http.Cookie;
 import lombok.RequiredArgsConstructor;
+import org.apache.catalina.util.StandardSessionIdGenerator;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.concurrent.TimeUnit;
+
 @Service
 @RequiredArgsConstructor
-@Transactional
+@Transactional(readOnly = true)
 public class MemberService {
 
     private final MemberRepository memberRepository;
 
+    private final RedisTemplate<String, MemberSession> redisTemplate;
+
+    @Transactional
     public Member createMember(Member member) {
         validateMember(member.getEmail());
         return memberRepository.save(member);
+    }
+
+    public Cookie login(MemberLoginInfo memberLoginInfo) {
+        Member member = memberRepository.findByEmailAndPassword(
+                memberLoginInfo.getEmail(), memberLoginInfo.getPassword()).orElseThrow(()
+                -> new TodoApplicationException(ErrorCode.AUTHENTICATION_FAILED));
+
+        String sessionId = new StandardSessionIdGenerator().generateSessionId();
+        String sessionKey = "TODO_SESSION:" + sessionId;
+        redisTemplate.opsForValue().set(sessionKey, new MemberSession(member.getId()), 30L, TimeUnit.MINUTES);
+
+        Cookie cookie = new Cookie("SESSION", sessionId);
+        cookie.setMaxAge(1800);
+        cookie.setPath("/");
+        cookie.setHttpOnly(true);
+        // 추후 적용 예정
+        // myCookie.setSecure(true); https 에서만 요청 허용
+        // myCookie.setDomain("exemple.com"); 요청 도메인 동적 처리
+        return cookie;
     }
 
     private void validateMember(String email) {

--- a/src/main/java/com/app/todolist/api/members/service/dto/MemberLoginInfo.java
+++ b/src/main/java/com/app/todolist/api/members/service/dto/MemberLoginInfo.java
@@ -1,0 +1,15 @@
+package com.app.todolist.api.members.service.dto;
+
+import lombok.Getter;
+
+@Getter
+public class MemberLoginInfo {
+
+    private final String email;
+    private final String password;
+
+    public MemberLoginInfo(String email, String password) {
+        this.email = email;
+        this.password = password;
+    }
+}

--- a/src/main/java/com/app/todolist/config/redis/dto/MemberSession.java
+++ b/src/main/java/com/app/todolist/config/redis/dto/MemberSession.java
@@ -1,10 +1,12 @@
 package com.app.todolist.config.redis.dto;
 
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
+@NoArgsConstructor
 public class MemberSession {
-    private final Long id;
+    private Long id;
 
     public MemberSession(Long id) {
         this.id = id;

--- a/src/main/java/com/app/todolist/domain/members/repository/MemberRepository.java
+++ b/src/main/java/com/app/todolist/domain/members/repository/MemberRepository.java
@@ -3,8 +3,12 @@ package com.app.todolist.domain.members.repository;
 import com.app.todolist.domain.members.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
     boolean existsByEmail(String email);
+
+    Optional<Member> findByEmailAndPassword(String email, String password);
 
 }

--- a/src/main/java/com/app/todolist/web/exception/ErrorCode.java
+++ b/src/main/java/com/app/todolist/web/exception/ErrorCode.java
@@ -10,6 +10,7 @@ public enum ErrorCode {
 
     DUPLICATED_MEMBER_ID(HttpStatus.CONFLICT, "이미 가입된 이메일이 존재합니다."),
     MEMBER_NOT_FOUND(HttpStatus.BAD_REQUEST, "회원이 존재하지 않습니다."),
+    AUTHENTICATION_FAILED(HttpStatus.UNAUTHORIZED, "아이디 또는 비밀번호를 확인하세요."),
     TODO_NOT_FOUND(HttpStatus.BAD_REQUEST, "TODO가 존재하지 않습니다."),
     INVALID_JSON_INPUT(HttpStatus.BAD_REQUEST, "%s 필드 값이 잘못되었습니다. [%s] 타입이어야 합니다.");
 

--- a/src/test/java/com/app/todolist/api/members/MemberServiceTest.java
+++ b/src/test/java/com/app/todolist/api/members/MemberServiceTest.java
@@ -1,17 +1,22 @@
 package com.app.todolist.api.members;
 
 import com.app.todolist.api.members.service.MemberService;
+import com.app.todolist.api.members.service.dto.MemberLoginInfo;
+import com.app.todolist.config.redis.dto.MemberSession;
 import com.app.todolist.domain.members.Member;
 import com.app.todolist.domain.members.repository.MemberRepository;
+import com.app.todolist.web.exception.ErrorCode;
 import com.app.todolist.web.exception.TodoApplicationException;
+import jakarta.servlet.http.Cookie;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.redis.core.RedisTemplate;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.*;
 
 @SpringBootTest
 class MemberServiceTest {
@@ -20,10 +25,21 @@ class MemberServiceTest {
     private MemberService memberService;
     @Autowired
     private MemberRepository memberRepository;
+    @Autowired
+    private RedisTemplate<String, MemberSession> redisTemplate;
 
     @AfterEach
     public void clear() {
         memberRepository.deleteAllInBatch();
+    }
+
+    private MemberLoginInfo loginMember(String email, String password) {
+        return new MemberLoginInfo(email, password);
+    }
+
+    private Member createTestMember(String email, String password) {
+        Member member = Member.create(email, password);
+        return memberRepository.save(member);
     }
 
     @Test
@@ -57,4 +73,56 @@ class MemberServiceTest {
         assertThat(exception.getExceptionMessage()).isEqualTo("이미 가입된 이메일이 존재합니다.");
     }
 
+    @Test
+    @DisplayName("회원이 로그인 시 Redis에 세션이 생성된다.")
+    public void sessionCreationTest() {
+        // given
+        Member member = createTestMember("tao@exemple.com", "1234");
+        MemberLoginInfo memberLoginInfo = loginMember("tao@exemple.com", "1234");
+
+        // when
+        Cookie cookie = memberService.login(memberLoginInfo);
+        String sessionId = cookie.getValue();
+        String sessionKey = "TODO_SESSION:" + sessionId;
+
+        // then
+        MemberSession memberSession = redisTemplate.opsForValue().get(sessionKey);
+
+        assertNotNull(memberSession);
+        assertEquals(member.getId(), memberSession.getId());
+    }
+
+    @Test
+    @DisplayName("회원이 로그인 시 쿠키가 생성된다.")
+    public void cookieCreationTest() {
+        // given
+        createTestMember("tao@exemple.com", "1234");
+        MemberLoginInfo memberLoginInfo = loginMember("tao@exemple.com", "1234");
+
+        // when
+        Cookie cookie = memberService.login(memberLoginInfo);
+
+        // then
+        assertNotNull(cookie);
+        assertEquals("SESSION", cookie.getName());
+        assertEquals(1800, cookie.getMaxAge());
+        assertTrue(cookie.isHttpOnly());
+        assertEquals("/", cookie.getPath());
+    }
+
+    @Test
+    @DisplayName("로그인 시 이메일 또는 비밀번호가 틀리면 예외가 발생한다.")
+    public void loginValidTest() {
+        // given
+        createTestMember("tao@exemple.com", "1234");
+        MemberLoginInfo memberLoginInfo = loginMember("valid@exemple.com", "1");
+
+        // when
+        TodoApplicationException exception = assertThrows(TodoApplicationException.class, ()
+                -> memberService.login(memberLoginInfo));
+
+        // then
+        assertThat(exception.getClass()).isEqualTo(TodoApplicationException.class);
+        assertThat(exception.getExceptionMessage()).isEqualTo(ErrorCode.AUTHENTICATION_FAILED.getMessage());
+    }
 }

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,7 +1,15 @@
 server:
   port: 80
+  servlet:
+    session:
+      timeout: 1800
 
 spring:
+  data:
+    redis:
+      host: localhost
+      port: 6379
+
   datasource:
     url: jdbc:h2:~/test
     username: sa


### PR DESCRIPTION
로그인 기능 구현

[POST] /api/members/login

로그인 시 세션 정보는 Redis에 저장된다.
로그인 시 쿠키에 세션정보 저장 후 응답한다.
토큰 및 쿠키의 유지시간은 30분으로 지정한다.
이메일 또는 비밀번호가 맞지 않을 시 예외가 발생한다.

- RequestBody
```json
{
    "email": "tao@exemple.com",
    "password": "1234"
}
```

- ResponseBody
```json
200 OK
```

```json
// 이메일 또는 비밀번호가 맞지 않을 경우 예외처리
{
    "code": 401,
    "message": "아이디 또는 비밀번호를 확인하세요."
}
```

close #39 