### PR TITLE
[#41] 회원가입 시 비밀번호 단방향 암호화 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
 
+    implementation 'org.mindrot:jbcrypt:0.4'
+
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'org.springframework.session:spring-session-data-redis'
 

--- a/src/main/java/com/app/todolist/api/members/controller/MemberController.java
+++ b/src/main/java/com/app/todolist/api/members/controller/MemberController.java
@@ -23,7 +23,7 @@ public class MemberController {
 
     @PostMapping
     public MemberResponse createMember(@RequestBody @Valid MemberRequest memberRequest) {
-        Member member = memberService.createMember(memberRequest.toEntity());
+        Member member = memberService.createMember(memberRequest.toCreate());
         return MemberResponse.of(member);
     }
 

--- a/src/main/java/com/app/todolist/api/members/controller/dto/request/MemberRequest.java
+++ b/src/main/java/com/app/todolist/api/members/controller/dto/request/MemberRequest.java
@@ -1,6 +1,6 @@
 package com.app.todolist.api.members.controller.dto.request;
 
-import com.app.todolist.domain.members.Member;
+import com.app.todolist.api.members.service.dto.MemberCreateInfo;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import lombok.NoArgsConstructor;
@@ -17,7 +17,7 @@ public class MemberRequest {
     @NotBlank(message = "비밀번호를 입력하세요.")
     private String password;
 
-    public Member toEntity() {
-        return Member.create(email, password);
+    public MemberCreateInfo toCreate() {
+        return new MemberCreateInfo(email, password);
     }
 }

--- a/src/main/java/com/app/todolist/api/members/service/dto/MemberCreateInfo.java
+++ b/src/main/java/com/app/todolist/api/members/service/dto/MemberCreateInfo.java
@@ -1,0 +1,15 @@
+package com.app.todolist.api.members.service.dto;
+
+import lombok.Getter;
+
+@Getter
+public class MemberCreateInfo {
+
+    private final String email;
+    private final String password;
+
+    public MemberCreateInfo(String email, String password) {
+        this.email = email;
+        this.password = password;
+    }
+}

--- a/src/main/java/com/app/todolist/domain/members/repository/MemberRepository.java
+++ b/src/main/java/com/app/todolist/domain/members/repository/MemberRepository.java
@@ -9,6 +9,6 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
     boolean existsByEmail(String email);
 
-    Optional<Member> findByEmailAndPassword(String email, String password);
+    Optional<Member> findByEmail(String email);
 
 }

--- a/src/test/java/com/app/todolist/api/members/BcryptTest.java
+++ b/src/test/java/com/app/todolist/api/members/BcryptTest.java
@@ -9,8 +9,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class BcryptTest {
 
     @Test
-    @DisplayName("회원 생성 시 비밀번호가 암호화되어 생성된다.")
-    void testPasswordEncryption() {
+    @DisplayName("비밀번호가 암호화되어 생성된다.")
+    public void passwordEncryptionTest() {
         // given
         String password = "1234";
 

--- a/src/test/java/com/app/todolist/api/members/BcryptTest.java
+++ b/src/test/java/com/app/todolist/api/members/BcryptTest.java
@@ -1,0 +1,25 @@
+package com.app.todolist.api.members;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mindrot.jbcrypt.BCrypt;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class BcryptTest {
+
+    @Test
+    @DisplayName("회원 생성 시 비밀번호가 암호화되어 생성된다.")
+    void testPasswordEncryption() {
+        // given
+        String password = "1234";
+
+        // when
+        String hashedPassword = BCrypt.hashpw(password, BCrypt.gensalt());
+
+        // then
+        assertThat(hashedPassword).isNotNull();
+        assertThat(password).isNotEqualTo(hashedPassword);
+        assertThat(BCrypt.checkpw(password, hashedPassword)).isTrue();
+    }
+}

--- a/src/test/java/com/app/todolist/api/members/MemberServiceTest.java
+++ b/src/test/java/com/app/todolist/api/members/MemberServiceTest.java
@@ -65,6 +65,36 @@ class MemberServiceTest {
     }
 
     @Test
+    @DisplayName("회원 생성 시 비밀번호가 암호화되어 생성된다.")
+    void testPasswordEncryption() {
+        // given
+        String password = "1234";
+
+        // when
+        String hashedPassword = BCrypt.hashpw(password, BCrypt.gensalt());
+
+        // then
+        assertThat(hashedPassword).isNotNull();
+        assertThat(password).isNotEqualTo(hashedPassword);
+        assertThat(BCrypt.checkpw(password, hashedPassword)).isTrue();
+    }
+
+    @Test
+    @DisplayName("회원 생성 시 비밀번호가 암호화되어 저장된다.")
+    void testCreateMember_passwordShouldBeEncrypted() {
+        // given
+        MemberCreateInfo memberCreateInfo = memberCreateInfo("tao@exemple.com", "1234");
+
+        // when
+        Member createdMember = memberService.createMember(memberCreateInfo);
+
+        // then
+        assertThat(createdMember).isNotNull();
+        assertThat(memberCreateInfo.getPassword()).isNotEqualTo(createdMember.getPassword());
+        assertThat(BCrypt.checkpw(memberCreateInfo.getPassword(), createdMember.getPassword())).isTrue();
+    }
+
+    @Test
     @DisplayName("로그인 아이디가 존재할 경우 예외가 발생한다.")
     public void validateMemberTest() {
         // given

--- a/src/test/java/com/app/todolist/api/members/MemberServiceTest.java
+++ b/src/test/java/com/app/todolist/api/members/MemberServiceTest.java
@@ -35,7 +35,7 @@ class MemberServiceTest {
         memberRepository.deleteAllInBatch();
     }
 
-    private MemberCreateInfo memberCreateInfo(String email, String password) {
+    private MemberCreateInfo createMemberInfo(String email, String password) {
         return new MemberCreateInfo(email, password);
     }
 
@@ -53,7 +53,7 @@ class MemberServiceTest {
     @DisplayName("로그인 아이디와 비밀번호로 회원을 생성한다.")
     public void createMemberTest() {
         // given
-        MemberCreateInfo member = memberCreateInfo("tao@exemple.com", "1234");
+        MemberCreateInfo member = createMemberInfo("tao@exemple.com", "1234");
         memberService.createMember(member);
 
         // when
@@ -66,9 +66,9 @@ class MemberServiceTest {
 
     @Test
     @DisplayName("회원 생성 시 비밀번호가 암호화되어 저장된다.")
-    void testCreateMember_passwordShouldBeEncrypted() {
+    public void createMemberPasswordShouldBeEncryptedTest() {
         // given
-        MemberCreateInfo memberCreateInfo = memberCreateInfo("tao@exemple.com", "1234");
+        MemberCreateInfo memberCreateInfo = createMemberInfo("tao@exemple.com", "1234");
 
         // when
         Member createdMember = memberService.createMember(memberCreateInfo);
@@ -83,8 +83,8 @@ class MemberServiceTest {
     @DisplayName("로그인 아이디가 존재할 경우 예외가 발생한다.")
     public void validateMemberTest() {
         // given
-        MemberCreateInfo member1 = memberCreateInfo("tao@exemple.com", "1234");
-        MemberCreateInfo member2 = memberCreateInfo("tao@exemple.com", "1234");
+        MemberCreateInfo member1 = createMemberInfo("tao@exemple.com", "1234");
+        MemberCreateInfo member2 = createMemberInfo("tao@exemple.com", "1234");
         memberService.createMember(member1);
 
         // when

--- a/src/test/java/com/app/todolist/api/members/MemberServiceTest.java
+++ b/src/test/java/com/app/todolist/api/members/MemberServiceTest.java
@@ -65,21 +65,6 @@ class MemberServiceTest {
     }
 
     @Test
-    @DisplayName("회원 생성 시 비밀번호가 암호화되어 생성된다.")
-    void testPasswordEncryption() {
-        // given
-        String password = "1234";
-
-        // when
-        String hashedPassword = BCrypt.hashpw(password, BCrypt.gensalt());
-
-        // then
-        assertThat(hashedPassword).isNotNull();
-        assertThat(password).isNotEqualTo(hashedPassword);
-        assertThat(BCrypt.checkpw(password, hashedPassword)).isTrue();
-    }
-
-    @Test
     @DisplayName("회원 생성 시 비밀번호가 암호화되어 저장된다.")
     void testCreateMember_passwordShouldBeEncrypted() {
         // given


### PR DESCRIPTION
사용 라이브러리
```properties
implementation 'org.mindrot:jbcrypt:0.4'
```
- 사용자의 비밀번호를 암호화하여 저장한다.
- 회원가입 시 사용자가 입력한 비밀번호는 단방향 해시 함수를 사용하여 암호화한다.
- 암호화된 비밀번호는 데이터베이스에 저장되어야 하며, 복호화가 불가능해야 한다.

```json
// as-is
  "password": "1234"

// to-be
  "password": "$2a$10$4nYxYIUEqn6tn4d/INNVde.OM/Ab6dDHdDZ8kCA5IyKa338vyYaK."
```

close #41 