### PR TITLE
[#43] 인증, 인가 처리 설정

### DIFF
--- a/src/main/java/com/app/todolist/config/auth/WebConfig.java
+++ b/src/main/java/com/app/todolist/config/auth/WebConfig.java
@@ -1,0 +1,33 @@
+package com.app.todolist.config.auth;
+
+import com.app.todolist.config.auth.checkAuth.AuthInterceptor;
+import com.app.todolist.config.auth.loginMember.LoginMemberArgumentResolver;
+import com.app.todolist.config.redis.dto.MemberSession;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
+
+@Configuration
+@RequiredArgsConstructor
+public class WebConfig implements WebMvcConfigurer {
+
+    private final LoginMemberArgumentResolver loginMemberArgumentResolver;
+    private final RedisTemplate<String, MemberSession> redisTemplate;
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(new AuthInterceptor(redisTemplate))
+                .addPathPatterns("/api/**")
+                .excludePathPatterns("/api/members/login", "/api/members");
+    }
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> argumentResolvers) {
+        argumentResolvers.add(loginMemberArgumentResolver);
+    }
+}

--- a/src/main/java/com/app/todolist/config/auth/checkAuth/AuthInterceptor.java
+++ b/src/main/java/com/app/todolist/config/auth/checkAuth/AuthInterceptor.java
@@ -1,0 +1,50 @@
+package com.app.todolist.config.auth.checkAuth;
+
+import com.app.todolist.config.redis.dto.MemberSession;
+import com.app.todolist.web.exception.ErrorCode;
+import com.app.todolist.web.exception.TodoApplicationException;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.web.method.HandlerMethod;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import java.util.Arrays;
+
+@RequiredArgsConstructor
+public class AuthInterceptor implements HandlerInterceptor {
+
+    private final RedisTemplate<String, MemberSession> redisTemplate;
+
+    private static final String SESSION_KEY = "TODO_SESSION:";
+
+    @Override
+    public boolean preHandle(HttpServletRequest httpServletRequest,
+                             HttpServletResponse httpServletResponse,
+                             Object handler) {
+        if (handler instanceof HandlerMethod handlerMethod) {
+            CheckAuth checkAuth = handlerMethod.getMethodAnnotation(CheckAuth.class);
+            if (checkAuth != null) {
+                String sessionId = getSessionIdFromCookies(httpServletRequest);
+
+                if (sessionId == null || redisTemplate.opsForValue().get(SESSION_KEY + sessionId) == null) {
+                    throw new TodoApplicationException(ErrorCode.LOGIN_FORBIDDEN);
+                }
+            }
+        }
+        return true;
+    }
+
+    private String getSessionIdFromCookies(HttpServletRequest httpServletRequest) {
+        if (httpServletRequest.getCookies() != null) {
+            return Arrays.stream(httpServletRequest.getCookies())
+                    .filter(cookie -> "SESSION".equals(cookie.getName()))
+                    .map(Cookie::getValue)
+                    .findFirst()
+                    .orElse(null);
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/app/todolist/config/auth/checkAuth/CheckAuth.java
+++ b/src/main/java/com/app/todolist/config/auth/checkAuth/CheckAuth.java
@@ -1,0 +1,11 @@
+package com.app.todolist.config.auth.checkAuth;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface CheckAuth {
+}

--- a/src/main/java/com/app/todolist/config/auth/loginMember/LoginMember.java
+++ b/src/main/java/com/app/todolist/config/auth/loginMember/LoginMember.java
@@ -1,0 +1,11 @@
+package com.app.todolist.config.auth.loginMember;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.PARAMETER)
+public @interface LoginMember {
+}

--- a/src/main/java/com/app/todolist/config/auth/loginMember/LoginMemberArgumentResolver.java
+++ b/src/main/java/com/app/todolist/config/auth/loginMember/LoginMemberArgumentResolver.java
@@ -1,0 +1,51 @@
+package com.app.todolist.config.auth.loginMember;
+
+import com.app.todolist.config.redis.dto.MemberSession;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.MethodParameter;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+import java.util.Arrays;
+
+@Component
+@RequiredArgsConstructor
+public class LoginMemberArgumentResolver implements HandlerMethodArgumentResolver {
+
+    private final HttpServletRequest httpServletRequest;
+    private final RedisTemplate<String, MemberSession> redisTemplate;
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.hasParameterAnnotation(LoginMember.class);
+    }
+
+    @Override
+    public MemberSession resolveArgument(MethodParameter parameter,
+                                         ModelAndViewContainer mavContainer,
+                                         NativeWebRequest webRequest,
+                                         WebDataBinderFactory binderFactory) {
+        String sessionId = getSessionIdFromCookies(httpServletRequest);
+        if (sessionId != null) {
+            return redisTemplate.opsForValue().get("TODO_SESSION:" + sessionId);
+        }
+        return null;
+    }
+
+    private String getSessionIdFromCookies(HttpServletRequest httpServletRequest) {
+        if (httpServletRequest.getCookies() != null) {
+            return Arrays.stream(httpServletRequest.getCookies())
+                    .filter(cookie -> "SESSION".equals(cookie.getName()))
+                    .map(Cookie::getValue)
+                    .findFirst()
+                    .orElse(null);
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/app/todolist/config/redis/dto/MemberSession.java
+++ b/src/main/java/com/app/todolist/config/redis/dto/MemberSession.java
@@ -6,9 +6,9 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor
 public class MemberSession {
-    private Long id;
+    private Long memberId;
 
-    public MemberSession(Long id) {
-        this.id = id;
+    public MemberSession(Long memberId) {
+        this.memberId = memberId;
     }
 }

--- a/src/main/java/com/app/todolist/web/exception/ErrorCode.java
+++ b/src/main/java/com/app/todolist/web/exception/ErrorCode.java
@@ -12,7 +12,8 @@ public enum ErrorCode {
     MEMBER_NOT_FOUND(HttpStatus.BAD_REQUEST, "회원이 존재하지 않습니다."),
     AUTHENTICATION_FAILED(HttpStatus.UNAUTHORIZED, "아이디 또는 비밀번호를 확인하세요."),
     TODO_NOT_FOUND(HttpStatus.BAD_REQUEST, "TODO가 존재하지 않습니다."),
-    INVALID_JSON_INPUT(HttpStatus.BAD_REQUEST, "%s 필드 값이 잘못되었습니다. [%s] 타입이어야 합니다.");
+    INVALID_JSON_INPUT(HttpStatus.BAD_REQUEST, "%s 필드 값이 잘못되었습니다. [%s] 타입이어야 합니다."),
+    LOGIN_FORBIDDEN(HttpStatus.FORBIDDEN, "로그인 후 이용해주세요.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/test/java/com/app/todolist/api/members/MemberServiceTest.java
+++ b/src/test/java/com/app/todolist/api/members/MemberServiceTest.java
@@ -111,7 +111,7 @@ class MemberServiceTest {
         MemberSession memberSession = redisTemplate.opsForValue().get(sessionKey);
 
         assertNotNull(memberSession);
-        assertEquals(member.getId(), memberSession.getId());
+        assertEquals(member.getId(), memberSession.getMemberId());
     }
 
     @Test


### PR DESCRIPTION
- 인가
  - @CheckAuth `커스텀 어노테이션`
  - 현재 권한에 대한 정보는 없으나, 추후 API 개발을 고려하여 인가부분 설정 추가

- 인증
  - @LoginMember `커스텀 어노테이션`
  - 해당 어노테이션을 통해 로그인 된 `Member`의 `Session`정보를 불러온다.

```java
// exemple
    @CheckAuth
    @PostMapping
    public TodoResponse createTodo(
            @RequestBody @Valid TodoRequest todoRequest,
            @LoginMember MemberSession memberSession) {
        Todo todo = todoService.createTodo(
                memberSession.getMemberId(), todoRequest.getTitle(), todoRequest.getContent());
        return TodoResponse.of(todo);
    }

// 추후 권한 적용 시
@CheckAuth(memberRole = USER)
```

close #43 