### PR TITLE
[#51] GitHub Action CI 설정

### DIFF
--- a/.github/workflows/todo-build-and-test.yml
+++ b/.github/workflows/todo-build-and-test.yml
@@ -1,0 +1,49 @@
+name: TodoBuildAndTest
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+      - issue/**
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v3
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+
+      - name: Install Docker Compose
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y docker-compose
+
+      - name: Set up Docker Compose
+        run: |
+          docker-compose up -d
+          docker-compose ps
+
+      - name: Wait for services to be ready
+        run: |
+          until docker-compose exec -T mysql mysqladmin ping -h"127.0.0.1" --silent; do
+            echo "Waiting for MySQL to be ready..."
+            sleep 5
+          done
+          sleep 10
+
+      - name: Build with Gradle
+        run: ./gradlew clean build -Duser.language=ko -Duser.country=KR
+
+      - name: Tear down Docker Compose
+        if: always()
+        run: docker-compose down


### PR DESCRIPTION
자동화된 빌드 및 테스트를 위한 GitHub Actions 워크플로우 추가
푸시 및 PR 이벤트에 반응하여, 다음 작업을 자동으로 실행

- 동작 과정
1. `코드 체크아웃`: 최신 코드를 GitHub Actions 환경에 체크아웃
2. `JDK 21 설정`: Gradle 빌드를 위해 JDK 21을 설치
3. `Docker Compose 설정`: DB 설정에 대한 Docker Compose 환경을 설정하고 실행
4. `서비스 준비 대기`: MySQL이 준비될 때까지 대기
5. `Gradle 빌드 및 테스트`: 프로젝트를 클린 빌드하고 테스트를 실행
6. `Docker Compose 종료`: 빌드 후 Docker Compose 환경을 종료하고 리소스 정리

- 기대 효과
Push 또는 PR 생성 시, 자동으로 빌드 및 테스트가 실행되도록 하여 코드 품질을 보장
CI 파이프라인을 통해, 배포 전 코드가 정상적으로 작동하는지 확인

> 추후 적용 예정
> `Gradle 캐시 설정`: Gradle 의존성을 캐시하여 빌드 성능 향상