### PR TITLE
[#55] 인증, 인가 TTL갱신 로직 추가

### DIFF
--- a/src/main/java/com/app/todolist/api/session/service/SessionService.java
+++ b/src/main/java/com/app/todolist/api/session/service/SessionService.java
@@ -30,6 +30,10 @@ public class SessionService {
     }
 
     public MemberSession findSession(String sessionId) {
-        return redisTemplate.opsForValue().get(SESSION_PREFIX + sessionId);
+        MemberSession memberSession = redisTemplate.opsForValue().get(SESSION_PREFIX + sessionId);
+        if (memberSession != null) {
+            redisTemplate.expire(SESSION_PREFIX + sessionId, SESSION_TIMEOUT, TimeUnit.MINUTES);
+        }
+        return memberSession;
     }
 }

--- a/src/main/java/com/app/todolist/api/todos/controller/dto/TodoSearchResponse.java
+++ b/src/main/java/com/app/todolist/api/todos/controller/dto/TodoSearchResponse.java
@@ -26,7 +26,7 @@ public class TodoSearchResponse {
         return TodoSearchResponse.builder()
                 .memberId(todo.getMember().getId())
                 .title(todo.getTitle())
-                .status(TodoStatus.TODO)
+                .status(todo.getStatus())
                 .createdAt(todo.getCreatedAt())
                 .updatedAt(todo.getUpdatedAt())
                 .build();


### PR DESCRIPTION
현재 TTL 갱신 로직이 작성되어 있지 않아 로그인 된 유저 새로운 요청 시 TTL 갱신되도록 로직 수정
TodoSearchResponse status 고정으로 응답되던 로직 수정

SessionService

```java
// as-is
    public MemberSession findSession(String sessionId) {
        return redisTemplate.opsForValue().get(SESSION_PREFIX + sessionId);
    }

// to-be
    public MemberSession findSession(String sessionId) {
        MemberSession memberSession = redisTemplate.opsForValue().get(SESSION_PREFIX + sessionId);
        if (memberSession != null) {
            redisTemplate.expire(SESSION_PREFIX + sessionId, SESSION_TIMEOUT, TimeUnit.MINUTES); // TTL 갱신
        }
        return memberSession;
    }
```

close #55 